### PR TITLE
Use correct instance names passed to the functions in code examples

### DIFF
--- a/js/red-javascript-style-guide/why-disallow-class.md
+++ b/js/red-javascript-style-guide/why-disallow-class.md
@@ -115,15 +115,15 @@ const multiverseHero = createMultiverseHero({ name: `Jace` });
 
 // add methods
 const changeUniverse = (multiverseHero, universe) => {
-    hero.concentrationLevel -= 20;
-    hero.currentUniverse = universe;
+    multiverseHero.concentrationLevel -= 20;
+    multiverseHero.currentUniverse = universe;
 };
 
 // change existing
 const moveMultiverseHero = (multiverseHero, position) => {
     // do something before or after
     moveHero(multiverseHero, position);
-    hero.concentrationLevel -= 1;
+    multiverseHero.concentrationLevel -= 1;
 };
 
 changeUniverse(multiverseHero, 2);


### PR DESCRIPTION
The code examples refer to the instance passed as the first parameter to the function. A few of them do not use the correct instance names. This update fixes it to avoid confusion to the readers.